### PR TITLE
fix not subscriptable

### DIFF
--- a/lightglue_onnx/superpoint.py
+++ b/lightglue_onnx/superpoint.py
@@ -72,7 +72,7 @@ def simple_nms(scores, nms_radius: int):
 @torch.jit.script_if_tracing
 def top_k_keypoints(
     keypoints: torch.Tensor, scores: torch.Tensor, k: int
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor]:
     if k >= keypoints.shape[0]:
         return keypoints, scores
     else:


### PR DESCRIPTION
When I try to run export.py with command
`python export.py --img_size 1920--extractor_type superpoint --extractor_path weights/superpoint.onnx --lightglue_path weights/superpoint_lightglue.onnx  --dynamic `,
I encounter an error,
 ```Traceback (most recent call last):
  File "export.py", line 6, in <module>
    from lightglue_onnx import DISK, LightGlue, LightGlueEnd2End, SuperPoint
  File "/home/yujr/features/LightGlue-ONNX/lightglue_onnx/__init__.py", line 4, in <module>
    from .superpoint import SuperPoint
  File "/home/yujr/features/LightGlue-ONNX/lightglue_onnx/superpoint.py", line 75, in <module>
    ) -> tuple[torch.Tensor, torch.Tensor]:
TypeError: 'type' object is not subscriptable ```

Therefore, I make a little modify to fix this bug.