### PR TITLE
Use providers argument for extractor

### DIFF
--- a/onnx_runner/lightglue.py
+++ b/onnx_runner/lightglue.py
@@ -12,7 +12,7 @@ class LightGlueRunner:
         self.extractor = (
             ort.InferenceSession(
                 extractor_path,
-                providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+                providers=providers,
             )
             if extractor_path is not None
             else None


### PR DESCRIPTION
Replaces hard-coded providers in extractor's `InferenceSession` with input providers argument.